### PR TITLE
Fail iad check on adoc warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Core walkthroughs for the tutorial-web-app",
   "main": "index.js",
   "scripts": {
-    "test": "iad -d ./walkthroughs"
+    "test": "iad -W error -d ./walkthroughs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
e.g. fail the CI/tests if this kind of warning is found

```
WARN section title out of sequence: expected level 1, got level 2 at <stdin>: line 13
npm ERR! Test failed.  See above for more details.
```