### PR TITLE
INTLY-381 - open resources in new window

### DIFF
--- a/walkthroughs/1-integrating-event-and-api-driven-apps/walkthrough.adoc
+++ b/walkthroughs/1-integrating-event-and-api-driven-apps/walkthrough.adoc
@@ -43,19 +43,19 @@ image::images/arch.png[integration, role="integr8ly-img-responsive"]
 [type=walkthroughResource,serviceName=fuse]
 .Fuse Online
 ****
-* link:{fuse-url}[Console]
+* link:{fuse-url}[Console, window="_blank"]
 ****
 
 [type=walkthroughResource,serviceName=amq-broker-72-persistence]
 .AMQ
 ****
-* link:{amq-url}[Management Console]
+* link:{amq-url}[Management Console, window="_blank"]
 ****
 
 [type=walkthroughResource,serviceName=openshift]
 .Red Hat OpenShift
 ****
-* link:{openshift-host}/console[Console]
+* link:{openshift-host}/console[Console, window="_blank"]
 ****
 
 :sectnums:

--- a/walkthroughs/1A-enmasse-event-and-api-driven-apps/walkthrough.adoc
+++ b/walkthroughs/1A-enmasse-event-and-api-driven-apps/walkthrough.adoc
@@ -42,19 +42,19 @@ image::images/arch.png[integration, role="integr8ly-img-responsive"]
 [type=walkthroughResource,serviceName=fuse]
 .Fuse Online
 ****
-* link:{fuse-url}[Console]
+* link:{fuse-url}[Console, window="_blank"]
 ****
 
 [type=walkthroughResource,serviceName=amq-broker-72-persistence]
 .AMQ
 ****
-* link:{amq-url}[Management Console]
+* link:{amq-url}[Management Console, window="_blank"]
 ****
 
 [type=walkthroughResource,serviceName=openshift]
 .Red Hat OpenShift
 ****
-* link:{openshift-host}/console[Console]
+* link:{openshift-host}/console[Console, window="_blank"]
 ****
 
 

--- a/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
+++ b/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
@@ -35,33 +35,33 @@ image::images/arch.png[integration, role="integr8ly-img-responsive"]
 [type=walkthroughResource,serviceName=openshift]
 .Red Hat OpenShift
 ****
-* link:{openshift-host}/console[Console]
-* link:https://help.openshift.com/[Openshift Online Help Center]
-* link:https://blog.openshift.com/[Openshift Blog]
+* link:{openshift-host}/console[Console, window="_blank"]
+* link:https://help.openshift.com/[Openshift Online Help Center, window="_blank"]
+* link:https://blog.openshift.com/[Openshift Blog, window="_blank"]
 ****
 
 [type=walkthroughResource,serviceName=launcher]
 .Launcher
 ****
-* link:{launcher-url}[Console]
-* link:https://developers.redhat.com/products/openshiftio/overview/[Launcher Overview]
-* link:https://launcher.fabric8.io/docs/[Launcher Documentation]
+* link:{launcher-url}[Console, window="_blank"]
+* link:https://developers.redhat.com/products/openshiftio/overview/[Launcher Overview, window="_blank"]
+* link:https://launcher.fabric8.io/docs/[Launcher Documentation, window="_blank"]
 ****
 
 [type=walkthroughResource,serviceName=che]
 .Eclipse Che
 ****
 * link:{che-url}[Console]
-* link:https://developers.redhat.com/products/che/overview/[Eclipse Che Overview]
-* link:https://www.eclipse.org/che/docs/index.html[Eclipse Che Documentation]
+* link:https://developers.redhat.com/products/che/overview/[Eclipse Che Overview, window="_blank"]
+* link:https://www.eclipse.org/che/docs/index.html[Eclipse Che Documentation, window="_blank"]
 ****
 
 [type=walkthroughResource,serviceName=3scale]
 .3Scale
 ****
-* link:{api-management-url}[Console]
-* link:https://developers.redhat.com/products/3scale/overview/[3Scale Overview]
-* link:https://www.3scale.net[3Scale Website]
+* link:{api-management-url}[Console, window="_blank"]
+* link:https://developers.redhat.com/products/3scale/overview/[3Scale Overview, window="_blank"]
+* link:https://www.3scale.net[3Scale Website, window="_blank"]
 ****
 
 :sectnums:

--- a/walkthroughs/publishing-walkthroughs/walkthrough.adoc
+++ b/walkthroughs/publishing-walkthroughs/walkthrough.adoc
@@ -18,8 +18,8 @@ NOTE: You must have access to the link:{openshift-host}[OpenShift Console].
 [type=walkthroughResource]
 .Links
 ****
-* link:{linkGettingStarted}[Getting Started]
-* link:{linkTroubleshooting}[Troubleshooting]
+* link:{linkGettingStarted}[Getting Started, window="_blank"]
+* link:{linkTroubleshooting}[Troubleshooting, window="_blank"]
 ****
 
 :sectnums:

--- a/walkthroughs/writing-walkthroughs/walkthrough.adoc
+++ b/walkthroughs/writing-walkthroughs/walkthrough.adoc
@@ -38,23 +38,23 @@ A short description for the walkthrough. <2>
 [type=walkthroughResource,serviceName=openshift]
 .Openshift
 ****
-* link:{openshift-host}/console[Open Console]
-* link:https://help.openshift.com/[Openshift Online Help Center]
-* link:https://blog.openshift.com/[Openshift Blog]
+* link:{openshift-host}/console[Open Console, window="_blank"]
+* link:https://help.openshift.com/[Openshift Online Help Center, window="_blank"]
+* link:https://blog.openshift.com/[Openshift Blog, window="_blank"]
 ****
 
 [type=walkthroughResource]
 .Asciidoc
 ****
-* link:http://asciidoc.org/[Asciidoc Homepage]
-* link:http://asciidoc.org/userguide.html#_introduction[User Guide]
+* link:http://asciidoc.org/[Asciidoc Homepage, window="_blank"]
+* link:http://asciidoc.org/userguide.html#_introduction[User Guide, window="_blank"]
 ****
 
 [type=walkthroughResource]
 .Links
 ****
-* link:{linkGettingStarted}[Getting Started]
-* link:{linkTroubleshooting}[Troubleshooting]
+* link:{linkGettingStarted}[Getting Started, window="_blank"]
+* link:{linkTroubleshooting}[Troubleshooting, window="_blank"]
 ****
 
 :sectnums:

--- a/walkthroughs/writing-walkthroughs/walkthrough.adoc
+++ b/walkthroughs/writing-walkthroughs/walkthrough.adoc
@@ -277,11 +277,13 @@ When users are following a Walkthrough you can display helpful information and l
 [type=walkthroughResource,serviceName=openshift]
 .OpenShift
 ****
-* link:{openshift-host}[Openshift Console]
+* link:{openshift-host}[Openshift Console, window="_blank"]
 ****
 ----
 
 Setting `serviceName` is optional. If set to the name of a middleware service, an icon indicating the service status will be displayed next to the resource. For a list of default services, see link:https://github.com/integr8ly/tutorial-web-app/blob/master/src/common/serviceInstanceHelpers.js[the value for DEFAULT_SERVICES].
+
+Setting the `window="_blank"` parameter for a walkthrough resource link is also optional, but ensures that the target of the link displays in a separate browser tab. If omitted, the content of the target's link will replace the walkthrough content in the current browser tab.
 
 Walkthrough resources must only be defined in the preamble section.
 
@@ -294,7 +296,7 @@ Walkthrough resources must only be defined in the preamble section.
 [type=walkthroughResource]
 .My resource
 ****
-* link:https://google.com[Helpful link]
+* link:https://google.com[Helpful link, window="_blank"]
 ****
 ----
 


### PR DESCRIPTION
Fixes INTLY-381.

Within a walkthrough, console and other links in the resources section were replacing the current Integreatly browser tab with the link's content. In contrast, the main Integreatly page Application section would open console and other links in a new browser tab. Request was to have the walkthrough resource links behave consistently with the application resource links and open in a new browser tab.

This is all handled in the asciidoc, as a parameter within the same brackets [ ] as the link title is specified (according to the official asciidoc documentation). Tested and verified in a local build.