### PR TITLE
Use attribute to render example verification tag in source so it does…

### DIFF
--- a/walkthroughs/writing-walkthroughs/walkthrough.adoc
+++ b/walkthroughs/writing-walkthroughs/walkthrough.adoc
@@ -385,9 +385,10 @@ As with resources, block attributes are used to define verifications
 
 . At the end of the Procedure section, right after the numbered list add:
 +
-[source,asciidoc]
+:verificationText: verification
+[source,asciidoc,subs="attributes"]
 ----
-[type=verification]
+[type={verificationText}]
 Check that the dashboard of service X reports no errors.
 ----
 


### PR DESCRIPTION
…nt get included in verification count

https://issues.jboss.org/browse/INTLY-485

The example verification tag in a source block in task 8 was being detected as a verification, making the webapp think there were 11 verifications when there were only 10.
```asciidoc
[source,asciidoc]
----
[type=verification]
Check that the dashboard of service X reports no errors.
----
```

This is because of the regex line here:
https://github.com/integr8ly/tutorial-web-app/blob/c2261f5e17d50d3a30aa5d5ecea67c4a15c36130/src/pages/tutorial/task/task.js#L126-L129

This 'fix' uses attribute substitution to avoid having the `[type=verification]` text appearing in the raw source, thereby not getting picked up by the regex, and thereby showing the correct percentage complete for the walkthrough i.e. 100% instead of just 90% in this case

![image](https://user-images.githubusercontent.com/878251/50930208-442cae80-1457-11e9-90fe-8fffb9a9b775.png)

![image](https://user-images.githubusercontent.com/878251/50929850-37f42180-1456-11e9-9d84-00de54fa6364.png)
