### PR TITLE
INTLY-936 Specify Che Java stack in walkthrough two

### DIFF
--- a/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
+++ b/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
@@ -23,7 +23,7 @@
 
 This walkthrough demonstrates how an API can be protected and rate limited.
 
-Organizations modernizing their applications typically create many APIs. 
+Organizations modernizing their applications typically create many APIs.
 It then becomes paramount to understand the usage of these APIs and to ensure they are protected, for example, from a Denial-of-service attack.
 It is possible to protect and limit access to APIs as part of an integration.
 
@@ -128,7 +128,7 @@ Modify the Fuse Aggregation App to aggregate flights data from the Arrivals & De
 . Log in to the link:{che-url}[Code Ready, window="_blank"] Dashboard
 
 . The *New Workspace* page is displayed. Create a new Workspace:
-.. Use the *Java* stack.
+.. Use the *Java 1.8* stack.
 .. Select the *Add or Import Project* button.
 .. Select the *Github* tab.
 .. Select the *Connect your Github Account* button.
@@ -244,7 +244,7 @@ Verify that you followed each step in the procedure above.  If you are still hav
 === Setting Fuse Aggregation App Endpoint Limits
 
 . Create a new *Application Plan*:
-.. Select *Applications > Application Plans* from the side navigation. 
+.. Select *Applications > Application Plans* from the side navigation.
 .. Select *Create Application Plan*.
 .. Enter the following for *Name* and *System name*:
 +


### PR DESCRIPTION
In CodeReady there are now two Java Stacks by default, this PR
specifies to use the Java 1.8 Stack.

Verification:
- Specify this branch in the WebApp CR
- Go through Walkthrough 2 and ensure it all reads/works as
expected