### PR TITLE
Update product names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tutorial-web-app-walkthroughs",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Core walkthroughs for the tutorial-web-app",
   "main": "index.js",
   "scripts": {

--- a/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
+++ b/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
@@ -4,7 +4,7 @@
 :messaging-service-version: 7.2
 :integration-service: Fuse
 :integration-service-version: 7.1
-:code-ready-service: Code Ready
+:code-ready-service: CodeReady Workspaces
 :launcher-service: Launcher
 :api-mgmt-service: 3Scale
 :AMQ-ProductLongName: Red Hat AMQ
@@ -49,11 +49,11 @@ image::images/arch.png[integration, role="integr8ly-img-responsive"]
 ****
 
 [type=walkthroughResource,serviceName=codeready]
-.Code Ready
+.CodeReady Workspaces
 ****
 * link:{che-url}[Console, window="_blank"]
-* link:https://developers.redhat.com/products/codeready-workspaces/overview/[Code Ready Overview, window="_blank"]
-* link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces_for_openshift/1.0.0/[Code Ready Documentation, window="_blank"]
+* link:https://developers.redhat.com/products/codeready-workspaces/overview/[{code-ready-service} Overview, window="_blank"]
+* link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces_for_openshift/1.0.0/[{code-ready-service} Documentation, window="_blank"]
 ****
 
 [type=walkthroughResource,serviceName=3scale]
@@ -125,7 +125,7 @@ Modify the Fuse Aggregation App to aggregate flights data from the Arrivals & De
 
 // TODO placeholders for product names
 // TODO project name
-. Log in to the link:{che-url}[Code Ready, window="_blank"] Dashboard
+. Log in to the link:{che-url}[{code-ready-service}, window="_blank"] Dashboard
 
 . The *New Workspace* page is displayed. Create a new Workspace:
 .. Use the *Java 1.8* stack.

--- a/walkthroughs/writing-walkthroughs/walkthrough.adoc
+++ b/walkthroughs/writing-walkthroughs/walkthrough.adoc
@@ -104,9 +104,9 @@ Try downloading the link:https://github.com/integr8ly/walkthrough-template/archi
 
 <1> This is a required directory. All walkthroughs are defined under `walkthroughs`.
 
-<2> The directory name of a walkthrough. This is also displayed in the URL of the web app. 
+<2> The directory name of a walkthrough. This is also displayed in the URL of the web app.
 
-<3> All images for the walkthrough. 
+<3> All images for the walkthrough.
 
 <4> *walkthrough.adoc* is where the content of the walkthrough is written in asciidoc format.
 <5> *walkthrough.json* is the manifest file of the walkthrough where you can define extra dependencies.
@@ -177,7 +177,7 @@ Using the repository you created in the first task:
 
 . Add an introduction paragraph to your preamble.
 
-. Add another paragraph with more information about the walkthrough. 
+. Add another paragraph with more information about the walkthrough.
 
 . Commit your changes
 +
@@ -201,7 +201,7 @@ Check your git credentials and that you pushed to the correct remote repository.
 [time=5]
 == Adding tasks
 
-Walkthroughs are organized in tasks. A task becomes one single page in the Webapp. 
+Walkthroughs are organized in tasks. A task becomes one single page in the Webapp.
 
 Tasks are introduced by a second level heading (`==`).
 
@@ -423,18 +423,14 @@ Other attributes that are available to Walkthrough authors are:
 
 * Default attributes:
 ** OpenShift App Host: `\{openshift-app-host}`
-** Che URL: `\{che-url}`.
+** CodeReady Workspaces URL: `\{che-url}`.
 ** Fuse URL: `\{fuse-url}`
 ** Launcher URL: `\{launcher-url}`
 ** API Management URL: `\{api-management-url}`
-** AMQ URL: `\{amq-url}`
-** AMQ Broker URL: `\{amq-broker-tcp-url}`
-** AMQ Credential Username: `\{amq-credentials-username}`
-** AMQ Credential Password: `\{amq-credentials-password}`
-** EnMasse URL: `\{enmasse-url}`
-** EnMasse Broker URL: `\{enmasse-broker-url}`
-** EnMasse Credential Username: `\{enmasse-credentials-username}`
-** EnMasse Credential Password: `\{enmasse-credentials-password}`
+** AMQ Online URL: `\{enmasse-url}`
+** AMQ Online Broker URL: `\{enmasse-broker-url}`
+** AMQ Online Credential Username: `\{enmasse-credentials-username}`
+** AMQ Online Credential Password: `\{enmasse-credentials-password}`
 * Custom attributes:
 ** NodeJS Frontend App Route (provisioned from walkthrough.json): `\{route-frontend-host}`
 


### PR DESCRIPTION
Using `Red Hat CodeReady Workspaces` instead of `Code Ready/CodeReady/Che` (https://developers.redhat.com/products/codeready-workspaces/overview/)

Also removes references to AMQ as we don't provision it anymore.

@tremes @finp Mind taking a look? I'm not sure whether the long name `Red Hat ....` should be used everywhere or if it's ok to just use `CodeReady` in the walkthrough body?

@tremes You should be able to update the webapp CR to reference this branch to test it out on a cluster.

@maleck13 @finp A lot of products seem to be using out-of-date or shortened names (`Launcher`, `3Scale`, `EnMasse` etc.), do we want to update all of these in the `v1.2.x` release? If so, I can make those changes in this PR