### PR TITLE
Update text about 3scale route

### DIFF
--- a/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
+++ b/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
@@ -252,7 +252,7 @@ Verify that you followed each step in the procedure above.  If you are still hav
 https://wt2-{user-sanitized-username}-3scale.{openshift-app-host}
 ----
 +
-Note that this route should point to the shared staging APIcast in the *3scale* project in OpenShift.  Your administrator should have created this route for you. If it does not exist, contact your administrator to create the route.
+Note that this route will point to the shared staging APIcast in the *3scale* project in OpenShift. Alternatively, it will point to the wildcard APIcast if the wildcard proxy is enabled in your cluster.
 
 . Select *Update & test in Staging Environment*
 


### PR DESCRIPTION
See related PR https://github.com/integr8ly/tutorial-web-app/pull/450

This text that explains the 3scale staging route allows for clusters where the 3scale wildcard router is in place.
