### PR TITLE
INTLY-1525 Add attributes syntax for fuse flights aggregator host pla…

### DIFF
--- a/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
+++ b/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
@@ -109,6 +109,7 @@ Verify that you followed each step in the procedure above.  If you are still hav
 
 .Prerequisite 
 The following URL must be available before attempting this procedure:
+[subs="attributes+"]
 ----
 {route-fuse-flights-aggregator-host}
 ----


### PR DESCRIPTION
…ceholder

See https://issues.jboss.org/browse/INTLY-1525.

To verify, follow through Task 1 of the walkthrough to the point of where the route host is shown.
It should be shown after the Route is created in openshift