### PR TITLE
updates for fuse 7.3

### DIFF
--- a/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.adoc
+++ b/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.adoc
@@ -221,8 +221,6 @@ To allow Fuse Online to consume messages placed on the queue by the Node.js weba
 . Select the *Create Connection* button to start the *Create Connection* wizard.
 
 . Select *AMQP* to configure an *AMQP Message Broker* connection.
-+
-NOTE: Avoid choosing the similarly named *AMQ Message Broker*.
 
 . Enter the connection URI relating to {enmasse}:
 +
@@ -326,7 +324,7 @@ work-queue-requests
 
 . When prompted to *Choose an Action*, select *Create a fruit*.
 
-. When prompted to *Add to Integration*, select *Add a Step*.
+. When prompted to *Add to Integration*, click on the blue *+* icon in the left panel.
 
 . Select *Data Mapper* to map source and target fields in the corresponding JSON schemas:
 .. Expand the *body* item in the *Target* tree to reveal the *name* item.


### PR DESCRIPTION
Update for the Fuse 7.3 UI. No more `Add a step` button. Also the AMQ and AMQP integrations are no longer indistinguishable, so we can remove the note.

Verification steps:
1) On a cluster with Fuse 7.3, update the webapp operator to
```
WALKTHROUGH_LOCATIONS: https://github.com/integr8ly/tutorial-web-app-walkthroughs#INTLY-1861
```
2) Follow WT 1a and make sure the instructions make sense