### PR TITLE
Add IDs, and update for Fuse console changes

### DIFF
--- a/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.adoc
+++ b/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.adoc
@@ -90,10 +90,10 @@ work-queue-requests
 . Monitor the AMQ Online console until a green check mark is displayed beside the new address. 
 Creating an address may take some time. 
 
-[type=verification, id="wt1a_1_verification"]
+[type=verification, id="wt1a_1_1_verification"]
 Is the newly created address displayed on the *Addresses* screen of the link:{enmasse-url}[AMQ Online, window="_blank", id="wt1a_1_CYW_enmasse-url"] console?
 
-[type=verificationFail, id="wt1a_1_verificationFail"]
+[type=verificationFail, id="wt1a_1_1_verificationFail"]
 Verify that you followed each step in the procedure above. If you are still having issues, contact your administrator.
 
 // end::task-creating-addresses[]
@@ -152,10 +152,10 @@ Walkthrough 1A CRUD Connector
 
 .. Click *Create API Connector*.
 
-[type=verification]
+[type=verification, id="wt1a_2_1_verification"]
 Is the new connector displayed on the *Customizations* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_1_CYW_fuse-url"] console?
 
-[type=verificationFail]
+[type=verificationFail, id="wt1a_2_1_verificationFail"]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
 
 // end::creating-api-connector[]
@@ -194,10 +194,10 @@ Walkthrough 1A CRUD Connection
 .. Click *Create*.
 
 
-[type=verification]
+[type=verification, id="wt1a_2_2_verification"]
 Is the new connection displayed on the *Connections* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_2_CYW_fuse-url"] console?
 
-[type=verificationFail]
+[type=verificationFail, id="wt1a_2_2_verificationFail"]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
 
 
@@ -259,11 +259,11 @@ Walkthrough 1A Messaging App
 . Click *Create*.
 
 
-[type=verification]
+[type=verification, id="wt1a_2_3_verification"]
 Is the new connection displayed on the *Connections* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_3_fuse-url"] console?
 
 
-[type=verificationFail]
+[type=verificationFail, id="wt1a_2_3_verificationFail"]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
 
 
@@ -345,10 +345,10 @@ Walkthrough 1A
 . Monitor the *Integration Summary* dashboard until a green check mark is displayed beside the new integration.
 The integration may take some time to complete building.
 
-[type=verification]
+[type=verification, id="wt1a_3_1_verification"]
 Is the integration displayed as *Running* on the *Integration* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_3_1_fuse-url"] console?
 
-[type=verificationFail]
+[type=verificationFail, id="wt1a_3_1_verificationFail"]
 
 ****
 . Wait for the integration to appear. This can take several minutes.
@@ -393,7 +393,7 @@ Pineapple
 . Check that the entry from the Node.js webapp is displayed.
 
 
-[type=verification]
+[type=verification, id="wt1a_4_1_verification"]
 ****
 View the activity log:
 
@@ -406,7 +406,7 @@ View the activity log:
 Is your activity displayed?
 ****
 
-[type=verificationFail]
+[type=verificationFail, id="wt1a_4_1_verificationFail"]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
 
 

--- a/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.adoc
+++ b/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.adoc
@@ -21,7 +21,7 @@ In this walkthrough, create a simple and intuitive integration with built-in mon
 * A Node.js webapp provides a method to create messages, in this example, a new inventory item.
 * A Spring Boot CRUD app provides a RESTful API, in this example, an inventory API.
 
-To create this integration, use link:{enmasse-url}[AMQ Online, window="_blank"] and API connectors in link:{fuse-url}[Red Hat Fuse Online, window="_blank"].
+To create this integration, use link:{enmasse-url}[AMQ Online, window="_blank", id="wt1a_GS_enmasse-url"] and API connectors in link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_GS_fuse-url"].
 
 All of the applications and services used in this walkthrough are running on Red Hat OpenShift.
 
@@ -40,13 +40,13 @@ image::images/arch.png[integration, role="integr8ly-img-responsive"]
 [type=walkthroughResource,serviceName=fuse]
 .Fuse Online
 ****
-* link:{fuse-url}[Console, window="_blank"]
+* link:{fuse-url}[Console, window="_blank", id="resources-fuse-url"]
 ****
 
 [type=walkthroughResource,serviceName=amq-online-standard]
 .AMQ Online
 ****
-* link:{enmasse-url}[Console, window="_blank"]
+* link:{enmasse-url}[Console, window="_blank", , id="resources-enmasse-url"]
 ****
 
 
@@ -72,7 +72,7 @@ image::images/arch.png[integration, role="integr8ly-img-responsive"]
 
 To route messages to the Spring Boot app, create an address in AMQ Online.
 
-. Log into link:{enmasse-url}[AMQ Online, window="_blank"].
+. Log into link:{enmasse-url}[AMQ Online, window="_blank", id="wt1a_1_1_enmasse-url"].
 . Select *Addresses* from the left hand menu.
 
 . Create a *requests* address:
@@ -90,10 +90,10 @@ work-queue-requests
 . Monitor the AMQ Online console until a green check mark is displayed beside the new address. 
 Creating an address may take some time. 
 
-[type=verification]
-Is the newly created address displayed on the *Addresses* screen of the link:{enmasse-url}[AMQ Online, window="_blank"] console?
+[type=verification, id="wt1a_1_verification"]
+Is the newly created address displayed on the *Addresses* screen of the link:{enmasse-url}[AMQ Online, window="_blank", id="wt1a_1_CYW_enmasse-url"] console?
 
-[type=verificationFail]
+[type=verificationFail, id="wt1a_1_verificationFail"]
 Verify that you followed each step in the procedure above. If you are still having issues, contact your administrator.
 
 // end::task-creating-addresses[]
@@ -122,7 +122,7 @@ Fuse Online is an enterprise integration platform that provides connectors for m
 It can be extended with custom connectors, using either OpenAPI definitions (Swagger) or JAR files.
 To create a connector for the RESTful API, register the OpenAPI definition as a *Customization*.
 
-. Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank"] console.
+. Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_1_1_fuse-url"] console.
 
 . Select *Customizations* from the left hand menu.
 
@@ -131,7 +131,7 @@ To create a connector for the RESTful API, register the OpenAPI definition as a 
 . When prompted to *Upload OpenAPI Specification*, select *Use a URL*:
 .. Enter the following in the URL field:
 +
-[subs="attributes+"]
+[subs="attributes+", id="route-crud-host-url"]
 ----
 {route-crud-host}/v2/api-docs
 ----
@@ -153,7 +153,7 @@ Walkthrough 1A CRUD Connector
 .. Click *Create API Connector*.
 
 [type=verification]
-Is the new connector displayed on the *Customizations* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank"] console?
+Is the new connector displayed on the *Customizations* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_1_CYW_fuse-url"] console?
 
 [type=verificationFail]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
@@ -175,7 +175,7 @@ Verify that you followed each step in the procedure above.  If you are still hav
 To enable Fuse Online to send messages from the queue to the Spring Boot CRUD app, create a connection in Red Hat Fuse Online using the API connector you just created.
 
 
-. Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank"] console.
+. Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_2_1_fuse-url"] console.
 
 . Select *Connections* from the left hand menu.
 
@@ -195,7 +195,7 @@ Walkthrough 1A CRUD Connection
 
 
 [type=verification]
-Is the new connection displayed on the *Connections* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank"] console?
+Is the new connection displayed on the *Connections* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_2_CYW_fuse-url"] console?
 
 [type=verificationFail]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
@@ -214,7 +214,7 @@ To allow Fuse Online to consume messages placed on the queue by the Node.js weba
 :openshift-url: https://master.city.openshiftworkshop.com/console/project/eval/overview
 :enmasse: AMQ Online
 
-. Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank"] console.
+. Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_3_1_fuse-url"] console.
 
 . Select *Connections* from the left hand menu.
 
@@ -260,7 +260,7 @@ Walkthrough 1A Messaging App
 
 
 [type=verification]
-Is the new connection displayed on the *Connections* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank"] console?
+Is the new connection displayed on the *Connections* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_3_fuse-url"] console?
 
 
 [type=verificationFail]
@@ -346,7 +346,7 @@ Walkthrough 1A
 The integration may take some time to complete building.
 
 [type=verification]
-Is the integration displayed as *Running* on the *Integration* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank"] console?
+Is the integration displayed as *Running* on the *Integration* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_3_1_fuse-url"] console?
 
 [type=verificationFail]
 
@@ -378,7 +378,7 @@ After setting up the integration between the Node.js and Spring Boot application
 :spring-url: http://spring-boot-rest-http-crud-spring-app.apps.city.openshiftworkshop.com/
 :fuse-url: https://eval.apps.city.openshiftworkshop.com/
 
-. Navigate to the link:{route-frontend-host}[Node.js webapp, window="_blank"].
+. Navigate to the link:{route-frontend-host}[Node.js webapp, window="_blank", id="wt1a_4_2_nodejs-app-url"].
 
 . Enter a value for *Fruit*, for example:
 +
@@ -388,7 +388,7 @@ Pineapple
 
 . Click *Send Request*.
 
-. Navigate to the link:{route-crud-host}[Spring Boot app, window="_blank"].
+. Navigate to the link:{route-crud-host}[Spring Boot app, window="_blank", id="wt1a_4_4_springboot-app-url" ].
 
 . Check that the entry from the Node.js webapp is displayed.
 
@@ -397,7 +397,7 @@ Pineapple
 ****
 View the activity log:
 
-. Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank"] console.
+. Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_4_CYW_1_fuse-url"] console.
 . Select *Integrations* from the left hand menu.
 . Select your integration.
 . Select the *Activity* tab.

--- a/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.adoc
+++ b/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.adoc
@@ -128,7 +128,7 @@ To create a connector for the RESTful API, register the OpenAPI definition as a 
 
 . Select the *Create API Connector* button to start the *API Client Connector* wizard.
 
-. When prompted to *Upload OpenAPI Specification*, select *Use a URL*:
+. When prompted to *Upload OpenAPI Document*, select *Use a URL*:
 .. Enter the following in the URL field:
 +
 [subs="attributes+", id="route-crud-host-url"]
@@ -220,7 +220,7 @@ To allow Fuse Online to consume messages placed on the queue by the Node.js weba
 
 . Select the *Create Connection* button to start the *Create Connection* wizard.
 
-. Select *AMQP* to configure an *AMQP Message Broker* connection.
+. Select *AMQP Message Broker* to configure an *AMQP* connection.
 +
 NOTE: Avoid choosing the similarly named *AMQ Message Broker*.
 

--- a/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.adoc
+++ b/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.adoc
@@ -90,10 +90,10 @@ work-queue-requests
 . Monitor the AMQ Online console until a green check mark is displayed beside the new address. 
 Creating an address may take some time. 
 
-[type=verification, id="wt1a_1_1_verification"]
+[type=verification]
 Is the newly created address displayed on the *Addresses* screen of the link:{enmasse-url}[AMQ Online, window="_blank", id="wt1a_1_CYW_enmasse-url"] console?
 
-[type=verificationFail, id="wt1a_1_1_verificationFail"]
+[type=verificationFail]
 Verify that you followed each step in the procedure above. If you are still having issues, contact your administrator.
 
 // end::task-creating-addresses[]
@@ -152,10 +152,10 @@ Walkthrough 1A CRUD Connector
 
 .. Click *Create API Connector*.
 
-[type=verification, id="wt1a_2_1_verification"]
+[type=verification]
 Is the new connector displayed on the *Customizations* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_1_CYW_fuse-url"] console?
 
-[type=verificationFail, id="wt1a_2_1_verificationFail"]
+[type=verificationFail]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
 
 // end::creating-api-connector[]
@@ -194,10 +194,10 @@ Walkthrough 1A CRUD Connection
 .. Click *Create*.
 
 
-[type=verification, id="wt1a_2_2_verification"]
+[type=verification]
 Is the new connection displayed on the *Connections* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_2_CYW_fuse-url"] console?
 
-[type=verificationFail, id="wt1a_2_2_verificationFail"]
+[type=verificationFail]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
 
 
@@ -259,11 +259,11 @@ Walkthrough 1A Messaging App
 . Click *Create*.
 
 
-[type=verification, id="wt1a_2_3_verification"]
-Is the new connection displayed on the *Connections* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_3_fuse-url"] console?
+[type=verification]
+Is the new connection displayed on the *Connections* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_2_3_CYW_fuse-url"] console?
 
 
-[type=verificationFail, id="wt1a_2_3_verificationFail"]
+[type=verificationFail]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
 
 
@@ -345,10 +345,10 @@ Walkthrough 1A
 . Monitor the *Integration Summary* dashboard until a green check mark is displayed beside the new integration.
 The integration may take some time to complete building.
 
-[type=verification, id="wt1a_3_1_verification"]
+[type=verification]
 Is the integration displayed as *Running* on the *Integration* screen of the link:{fuse-url}[Red Hat Fuse Online, window="_blank", id="wt1a_3_1_fuse-url"] console?
 
-[type=verificationFail, id="wt1a_3_1_verificationFail"]
+[type=verificationFail]
 
 ****
 . Wait for the integration to appear. This can take several minutes.
@@ -393,7 +393,7 @@ Pineapple
 . Check that the entry from the Node.js webapp is displayed.
 
 
-[type=verification, id="wt1a_4_1_verification"]
+[type=verification]
 ****
 View the activity log:
 
@@ -406,7 +406,7 @@ View the activity log:
 Is your activity displayed?
 ****
 
-[type=verificationFail, id="wt1a_4_1_verificationFail"]
+[type=verificationFail]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
 
 


### PR DESCRIPTION
Changes made to better reflect the content of the Fuse Console and avoid ambiguity in what the user is being asked to do.

The fuse console now refers to Upload OpenAPI Document, not Upload OpenAPI Specification.

![wt1a-page2_2 1 4_1 4_rc5 ](https://user-images.githubusercontent.com/10615211/57949927-ac940c80-78dd-11e9-90cb-3a47814d330a.png)
<img width="737" alt="fuse-dashboard-wt1a-page2_2 1 4_1 4_rc5 " src="https://user-images.githubusercontent.com/10615211/57949925-ac940c80-78dd-11e9-942b-7132f17e0322.png">

The walkthrough instructs 'Select AMQP to configure an AMQP Message Broker connection'.  This is ambiguous as there are two differing options which refer to AMQP Message Broker and AMQP Red Hat respectively.  To make this more explicit and remove the ambiguity I have changed it to 'Select AMQP Message Broker to configure an AMQP connection'.

![wt1a-page2_2 3 4_1 4_rc5](https://user-images.githubusercontent.com/10615211/57949929-ac940c80-78dd-11e9-9cf7-03e514d30fac.png)
<img width="474" alt="fuse-wt1a-page2_2 34_1 4_rc5" src="https://user-images.githubusercontent.com/10615211/57949926-ac940c80-78dd-11e9-924c-5c375306c947.png">





