### PR TITLE
ensure walkthrough 1a is openshift 4 compatible

### DIFF
--- a/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.json
+++ b/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.json
@@ -9,427 +9,138 @@
         "name": "fuse"
       }
     ],
-    "serviceInstances": [],
+    "serviceInstances": [
+      {
+        "metadata": {
+          "name": "spring-boot-rest-http-crud"
+        },
+        "spec": {
+          "clusterServiceClassExternalName": "spring-boot-rest-http-crud",
+          "clusterServicePlanExternalName": "default"
+        }
+      },
+      {
+        "metadata": {
+          "name": "nodejs-messaging-work-queue-frontend"
+        },
+        "spec": {
+          "clusterServiceClassExternalName": "nodejs-messaging-work-queue-frontend",
+          "clusterServicePlanExternalName": "default",
+          "parameters": {
+            "MESSAGING_SERVICE_PASSWORD": "{{ enmasse-credentials-password }}",
+            "MESSAGING_SERVICE_USER": "{{ enmasse-credentials-username }}",
+            "MESSAGING_SERVICE_HOST": "{{ enmasse-broker-url }}"
+          }
+        }
+      }
+    ],
     "templates": [
       {
-        "apiVersion": "v1",
+        "apiVersion": "template.openshift.io/v1",
         "kind": "Template",
         "metadata": {
-          "name": "spring-boot-rest-http-crud",
+          "name": "fruit-crud-app",
           "annotations": {
-            "iconClass": "icon-spring",
-            "tags": "spring-boot, rest, crud, java, microservice",
-            "openshift.io/display-name": "Spring Boot - REST HTTP and CRUD",
+            "iconClass": "icon-node",
+            "tags": "nodejs, crud",
+            "openshift.io/display-name": "Fruit CRUD Application",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "openshift.io/documentation-url": "https://appdev.prod-preview.openshift.io/docs/spring-boot-runtime.html#mission-crud-spring-boot-tomcat",
-            "description": "The Relational Database Backend booster expands on the REST API Level 0 booster to provide a basic example of performing create, read, update and delete (CRUD) operations on a PostgreSQL database using a simple HTTP API. CRUD operations are the four basic functions of persistent storage, widely used when developing an HTTP API dealing with a database."
+            "openshift.io/documentation-url": "https://github.com/integr8ly/walkthrough-applications.git",
+            "description": "Basic CRUD application for fruit"
           }
         },
-        "parameters": [
-          {
-            "name": "RUNTIME_VERSION",
-            "displayName": "OpenJDK 8 image version to use",
-            "description": "Specifies which version of the OpenShift OpenJDK 8 image to use",
-            "value": "1.3-8",
-            "required": true
-          }
-        ],
         "objects": [
           {
-            "apiVersion": "v1",
-            "kind": "ImageStream",
-            "metadata": {
-              "name": "spring-boot-rest-http-crud"
-            },
-            "spec": {}
-          },
-          {
-            "apiVersion": "v1",
-            "kind": "ImageStream",
-            "metadata": {
-              "name": "runtime"
-            },
-            "spec": {
-              "tags": [
-                {
-                  "name": "${RUNTIME_VERSION}",
-                  "from": {
-                    "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:${RUNTIME_VERSION}"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "apiVersion": "v1",
-            "kind": "Secret",
-            "metadata": {
-              "labels": {
-                "app": "spring-boot-rest-http-crud",
-                "provider": "snowdrop",
-                "version": "BOOSTER_VERSION",
-                "group": "io.openshift.booster"
-              },
-              "name": "my-database-secret"
-            },
-            "stringData": {
-              "user": "luke",
-              "password": "secret"
-            }
-          },
-          {
-            "apiVersion": "v1",
-            "kind": "Service",
-            "metadata": {
-              "labels": {
-                "app": "spring-boot-rest-http-crud",
-                "provider": "snowdrop",
-                "version": "BOOSTER_VERSION",
-                "group": "io.openshift.booster"
-              },
-              "name": "spring-boot-rest-http-crud"
-            },
-            "spec": {
-              "ports": [
-                {
-                  "name": "http",
-                  "port": 8080,
-                  "protocol": "TCP",
-                  "targetPort": 8080
-                }
-              ],
-              "selector": {
-                "app": "spring-boot-rest-http-crud",
-                "provider": "snowdrop",
-                "group": "io.openshift.booster"
-              }
-            }
-          },
-          {
-            "apiVersion": "v1",
             "kind": "DeploymentConfig",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
+              "name": "crud",
               "labels": {
-                "app": "spring-boot-rest-http-crud",
-                "provider": "snowdrop",
-                "version": "BOOSTER_VERSION",
-                "group": "io.openshift.booster"
-              },
-              "name": "spring-boot-rest-http-crud"
+                "app": "crud"
+              }
             },
             "spec": {
               "replicas": 1,
-              "revisionHistoryLimit": 2,
+              "revisionHistoryLimit": 10,
+              "test": false,
               "selector": {
-                "app": "spring-boot-rest-http-crud",
-                "provider": "snowdrop",
-                "group": "io.openshift.booster"
-              },
-              "strategy": {
-                "rollingParams": {
-                  "timeoutSeconds": 3600
-                },
-                "type": "Rolling"
+                "app": "crud"
               },
               "template": {
                 "metadata": {
                   "labels": {
-                    "app": "spring-boot-rest-http-crud",
-                    "provider": "snowdrop",
-                    "version": "BOOSTER_VERSION",
-                    "group": "io.openshift.booster"
+                    "app": "crud"
                   }
                 },
                 "spec": {
                   "containers": [
                     {
-                      "env": [
-                        {
-                          "name": "DB_USERNAME",
-                          "valueFrom": {
-                            "secretKeyRef": {
-                              "key": "user",
-                              "name": "my-database-secret"
-                            }
-                          }
-                        },
-                        {
-                          "name": "DB_PASSWORD",
-                          "valueFrom": {
-                            "secretKeyRef": {
-                              "key": "password",
-                              "name": "my-database-secret"
-                            }
-                          }
-                        },
-                        {
-                          "name": "JAVA_OPTIONS",
-                          "value": "-Dspring.profiles.active=openshift"
-                        },
-                        {
-                          "name": "KUBERNETES_NAMESPACE",
-                          "valueFrom": {
-                            "fieldRef": {
-                              "fieldPath": "metadata.namespace"
-                            }
-                          }
-                        }
-                      ],
-                      "image": "quay.io/integreatly/spring-boot-rest-http-crud:51e5091",
-                      "imagePullPolicy": "Always",
-                      "livenessProbe": {
-                        "httpGet": {
-                          "path": "/health",
-                          "port": 8080,
-                          "scheme": "HTTP"
-                        },
-                        "initialDelaySeconds": 180
-                      },
-                      "name": "spring-boot",
+                      "name": "crud",
+                      "image": "quay.io/integreatly/fruit-crud-app:1.0.1",
                       "ports": [
                         {
                           "containerPort": 8080,
-                          "name": "http",
-                          "protocol": "TCP"
-                        },
-                        {
-                          "containerPort": 8778,
-                          "name": "jolokia",
-                          "protocol": "TCP"
-                        }
-                      ],
-                      "readinessProbe": {
-                        "httpGet": {
-                          "path": "/health",
-                          "port": 8080,
-                          "scheme": "HTTP"
-                        },
-                        "initialDelaySeconds": 10
-                      },
-                      "securityContext": {
-                        "privileged": false
-                      }
-                    }
-                  ]
-                }
-              },
-              "triggers": [
-                {
-                  "imageChangeParams": {
-                    "automatic": true,
-                    "containerNames": [
-                      "spring-boot"
-                    ],
-                    "from": {
-                      "kind": "ImageStreamTag",
-                      "name": "spring-boot-rest-http-crud:latest"
-                    }
-                  },
-                  "type": "ConfigChange"
-                }
-              ]
-            }
-          },
-          {
-            "apiVersion": "v1",
-            "kind": "Route",
-            "metadata": {
-              "labels": {
-                "app": "spring-boot-rest-http-crud",
-                "provider": "snowdrop",
-                "version": "BOOSTER_VERSION",
-                "group": "io.openshift.booster"
-              },
-              "name": "crud"
-            },
-            "spec": {
-              "port": {
-                "targetPort": 8080
-              },
-              "to": {
-                "kind": "Service",
-                "name": "spring-boot-rest-http-crud"
-              }
-            }
-          },
-          {
-            "apiVersion": "v1",
-            "kind": "ImageStream",
-            "metadata": {
-              "annotations": {
-                "openshift.io/generated-by": "OpenShiftNewApp"
-              },
-              "creationTimestamp": null,
-              "labels": {
-                "app": "my-database"
-              },
-              "name": "my-database"
-            },
-            "spec": {
-              "lookupPolicy": {
-                "local": false
-              },
-              "tags": [
-                {
-                  "annotations": {
-                    "openshift.io/imported-from": "openshift/postgresql-92-centos7"
-                  },
-                  "from": {
-                    "kind": "DockerImage",
-                    "name": "openshift/postgresql-92-centos7"
-                  },
-                  "generation": null,
-                  "importPolicy": {},
-                  "name": "latest",
-                  "referencePolicy": {
-                    "type": ""
-                  }
-                }
-              ]
-            },
-            "status": {
-              "dockerImageRepository": ""
-            }
-          },
-          {
-            "apiVersion": "v1",
-            "kind": "DeploymentConfig",
-            "metadata": {
-              "annotations": {
-                "openshift.io/generated-by": "OpenShiftNewApp"
-              },
-              "creationTimestamp": null,
-              "labels": {
-                "app": "my-database"
-              },
-              "name": "my-database"
-            },
-            "spec": {
-              "replicas": 1,
-              "selector": {
-                "app": "my-database",
-                "deploymentconfig": "my-database"
-              },
-              "strategy": {
-                "resources": {}
-              },
-              "template": {
-                "metadata": {
-                  "annotations": {
-                    "openshift.io/generated-by": "OpenShiftNewApp"
-                  },
-                  "creationTimestamp": null,
-                  "labels": {
-                    "app": "my-database",
-                    "deploymentconfig": "my-database"
-                  }
-                },
-                "spec": {
-                  "containers": [
-                    {
-                      "env": [
-                        {
-                          "name": "POSTGRESQL_DATABASE",
-                          "value": "my_data"
-                        },
-                        {
-                          "name": "POSTGRESQL_PASSWORD",
-                          "value": "secret"
-                        },
-                        {
-                          "name": "POSTGRESQL_USER",
-                          "value": "luke"
-                        }
-                      ],
-                      "image": "openshift/postgresql-92-centos7",
-                      "name": "my-database",
-                      "ports": [
-                        {
-                          "containerPort": 5432,
                           "protocol": "TCP"
                         }
                       ],
                       "resources": {},
-                      "volumeMounts": [
-                        {
-                          "mountPath": "/var/lib/pgsql/data",
-                          "name": "my-database-volume-1"
-                        }
-                      ]
+                      "terminationMessagePath": "/dev/termination-log",
+                      "terminationMessagePolicy": "File",
+                      "imagePullPolicy": "IfNotPresent"
                     }
                   ],
-                  "volumes": [
-                    {
-                      "emptyDir": {},
-                      "name": "my-database-volume-1"
-                    }
-                  ]
+                  "restartPolicy": "Always",
+                  "terminationGracePeriodSeconds": 30,
+                  "dnsPolicy": "ClusterFirst",
+                  "securityContext": {},
+                  "schedulerName": "default-scheduler"
                 }
-              },
-              "test": false,
-              "triggers": [
-                {
-                  "type": "ConfigChange"
-                },
-                {
-                  "imageChangeParams": {
-                    "automatic": true,
-                    "containerNames": [
-                      "my-database"
-                    ],
-                    "from": {
-                      "kind": "ImageStreamTag",
-                      "name": "my-database:latest"
-                    }
-                  },
-                  "type": "ImageChange"
-                }
-              ]
-            },
-            "status": {
-              "availableReplicas": 0,
-              "latestVersion": 0,
-              "observedGeneration": 0,
-              "replicas": 0,
-              "unavailableReplicas": 0,
-              "updatedReplicas": 0
+              }
             }
           },
           {
-            "apiVersion": "v1",
             "kind": "Service",
+            "apiVersion": "v1",
             "metadata": {
-              "annotations": {
-                "openshift.io/generated-by": "OpenShiftNewApp"
-              },
-              "creationTimestamp": null,
-              "labels": {
-                "app": "my-database"
-              },
-              "name": "my-database"
+              "name": "crud"
             },
             "spec": {
               "ports": [
                 {
-                  "name": "5432-tcp",
-                  "port": 5432,
                   "protocol": "TCP",
-                  "targetPort": 5432
+                  "port": 8080,
+                  "targetPort": 8080
                 }
               ],
               "selector": {
-                "app": "my-database",
-                "deploymentconfig": "my-database"
+                "app": "crud"
               }
+            }
+          },
+          {
+            "kind": "Route",
+            "apiVersion": "route.openshift.io/v1",
+            "metadata": {
+              "name": "crud"
             },
-            "status": null
+            "spec": {
+              "to": {
+                "kind": "Service",
+                "name": "crud"
+              },
+              "port": {
+                "targetPort": 8080
+              },
+              "tls": {
+                "termination": "edge"
+              },
+              "wildcardPolicy": "None"
+            }
           }
-        ],
-        "loadBalancer": {}
+        ]
       },
       {
-        "apiVersion": "v1",
+        "apiVersion": "template.openshift.io/v1",
         "kind": "Template",
         "metadata": {
           "name": "nodejs-messaging-work-queue-frontend",


### PR DESCRIPTION
currently, the template apiVersion used in the templates section of
walkthrough.json in walkthrough 1a is not compatible with openshift
4.

as the templates section is new and not yet included in a release
this change reintroduces the serviceInstances section for 1a, this
should be used in openshift 3 environments, and updates the templates
used to be compatible with openshift 4.

this results in the following:
- walkthrough.json templates section is openshift 4-only
- walkthrough.json serviceInstances section is openshift 3-only
- walkthrough 1a now deploys an in-memory version of the crud app
  with a much faster startup time

openshift 3 verification:
- have an openshift 3 cluster with integreatly installed
- update the webapp operator to point WALKTHROUGH_LOCATIONS to this
  branch
- ensure the webapp redeploys
- ensure walkthrough 1a works as expected

openshift 4 verification:
- have an openshift 4 cluster with integreatly installed
- update the webapp version with the version provided via comment
- update WALKTHROUGH_LOCATIONS to point to this branch
- ensure walkthrough 1a works as expected