### PR TITLE
ensure ocp4 wt1 services match ocp3

### DIFF
--- a/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.json
+++ b/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.json
@@ -131,9 +131,6 @@
               "port": {
                 "targetPort": 8080
               },
-              "tls": {
-                "termination": "edge"
-              },
               "wildcardPolicy": "None"
             }
           }


### PR DESCRIPTION
@dimitraz This will make the OpenShift 4 Route equivalent to the current OpenShift 3 version.

I will create a ticket to move them both to use tls and handle self-signed cert issues, but for now I think it makes sense to keep them consistent, and to not bundle this work into the current ticket.

verification:
- go to the `c41a` cluster
- go to the `opentlc-mg-tuto-7ee5` namespace
- go to `networking -> routes`
- ensure the `crud` route no longer has `tls` configured