### PR TITLE
make walkthroughs 3scale 2.7 compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tutorial-web-app-walkthroughs",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tutorial-web-app-walkthroughs",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Core walkthroughs for the tutorial-web-app",
   "main": "index.js",
   "scripts": {

--- a/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.adoc
+++ b/walkthroughs/1A-integrate-event-and-api-driven-apps/walkthrough.adoc
@@ -196,7 +196,7 @@ To enable Fuse Online to send messages from the queue to the Spring Boot CRUD ap
 ----
 {route-crud-host}
 ----
-.. Accept the default value in the *Base path* field
+.. Enter `/` in the *Base path* field
 
 . When prompted with *Name connection*:
 .. Enter the following in the *Name* field:

--- a/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
+++ b/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
@@ -227,9 +227,9 @@ Verify that you followed each step in the procedure above.  If you are still hav
 
 === Adding a new Product to Red Hat 3scale
 
-. Select *Dashboard* from the top navigation bar dropdown.
-. From the *Dashboard*, in the *API* section, select the *Products* tab.
-. Select the *New Product* item.
+. Select *Dashboard* from the top navigation menu.
+. In the *API* section of the Dashboard, select the *Products* tab.
+. Click *New Product*.
 . Enter the following as the *Name* and *System name*:
 +
 [subs="attributes+"]
@@ -241,7 +241,7 @@ Verify that you followed each step in the procedure above.  If you are still hav
 
 === Configuring Product in Red Hat 3scale
 
-. Click the *Settings* item from the *Integration* dropdown menu in the side navigation.
+. Select *Settings* from the *Integration* menu in the side navigation.
 // The '{fuse-aggregation-app-apicast-route-url}' shoudl be the apicast-staging route url for this specific user. It can be looked up or deterministicly set.
 . In the *Staging Public Base URL*, enter:
 +

--- a/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
+++ b/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
@@ -201,10 +201,10 @@ Can you see the {3Scale-ProductName} Dashboard and navigate the main menu?
 [type=verificationFail]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
 
-=== Adding the Fuse Aggregation App Endpoint to Red Hat 3scale
+=== Adding the Fuse Aggregation App Backend to Red Hat 3scale
 
-. From the *Dashboard*, select the *New API* item.
-. Select the *Define Manually* option.
+. From the *Dashboard*, in the *API* section, select the *Backends* tab.
+. Select the *New Backend* item.
 
 +
 // TODO: dynamic fuse aggregation app name based on user id/email. "Only ASCII letters, numbers, dashes and underscores are allowed" for System name. e.g. fuse-aggregation-app-test01-example-com
@@ -216,17 +216,32 @@ Verify that you followed each step in the procedure above.  If you are still hav
 ----
 
 . Leave the *Description* field empty.
-
-. Click *Add API* at the bottom of the screen.
-
-. From the *Overview* screen, select the *Configure APIcast* button.
 // The 'fuse-aggregation-app-url' should be the url of the Fuse Aggregation App e.g. https://fuse-flights-aggregator-ak49.cluster-lfa3xlh.opentry.me/
-. In the *Private Base URL* field, enter:
+. In the *Private endpoint* field, enter:
 +
 [subs="attributes+"]
 ----
 {route-fuse-flights-aggregator-host}
 ----
+. Click *Create Backend* at the bottom of the screen.
+
+=== Adding a new Product to Red Hat 3scale
+
+. Select *Dashboard* from the top navigation bar dropdown.
+. From the *Dashboard*, in the *API* section, select the *Products* tab.
+. Select the *New Product* item.
+. Enter the following as the *Name* and *System name*:
++
+[subs="attributes+"]
+----
+{fuse-flights-aggregator-app-name}
+----
+. Leave the *Description* field empty.
+. Click *Create Product* at the bottom of the screen.
+
+=== Configuring Product in Red Hat 3scale
+
+. Click the *Settings* item from the *Integration* dropdown menu in the side navigation.
 // The '{fuse-aggregation-app-apicast-route-url}' shoudl be the apicast-staging route url for this specific user. It can be looked up or deterministicly set.
 . In the *Staging Public Base URL*, enter:
 +
@@ -234,10 +249,15 @@ Verify that you followed each step in the procedure above.  If you are still hav
 ----
 https://wt2-{user-sanitized-username}-3scale.{openshift-app-host}
 ----
+. Click *Update Product* at the bottom of the screen.
 
-. Click *Update & test in Staging Environment* to save your work.
-+
-You might encounter a *403: Authentication failed* or *503 Service Unavailable* message. You can ignore these messages, the issue is resolved in a later step.
+=== Using Backend and promoting Product to staging
+
+. Click the *Backends* item from the *Integration* dropdown menu in the side navigation
+. From the *Backends* screen, click *Add Backend* at the top right of the screen
+. Select the *{fuse-flights-aggregator-app-name}* item from the *Backend* dropdown menu
+. Leave the *Path* field empty
+. Click *Add to Product* at the bottom of the screen
 
 === Setting Fuse Aggregation App Endpoint Limits
 
@@ -262,7 +282,6 @@ You might encounter a *403: Authentication failed* or *503 Service Unavailable* 
 .. Set the *Period* to *hour*.
 .. Set the *Max. value* to *5*.
 .. Click *Create usage limit*.
-.. Click *Update Application plan*
 
 . Create a new *Application* for the *Developer* Group, assigned to the Plan:
 .. Select *Audience* from the top navigation bar dropdown.
@@ -280,7 +299,7 @@ You might encounter a *403: Authentication failed* or *503 Service Unavailable* 
 
 . Set a custom *User Key* for the application:
 .. On the *{fuse-flights-aggregator-app-name}* application screen you were redirected to, scroll to the *API Credentials* section.
-.. Click the green pencil icon beside the *API User Key*
+.. Click the green pencil icon beside the *User Key*
 .. In the *Set Custom User Key* modal dialog, enter:
 +
 [subs="attributes+"]
@@ -291,13 +310,11 @@ You might encounter a *403: Authentication failed* or *503 Service Unavailable* 
 
 [type=verification]
 ****
-. Select the *Overview* menu item in the side navigation.
+. Select the *Configuration* menu item from the *Integration* dropdown in the side navigation.
 
-. Scroll down and click the *Configure APIcast* button in the bottom right.
+. Click the *Promote to Staging* button.
 
-. Click the *Update & test in Staging Environment* button at the bottom again.
-
-. Is a success message displayed and a green line along the left side of the page visible?
+. Is the *Staging Environment* item in the *Environments* section now populated with information?
 ****
 
 [type=verificationFail]
@@ -317,7 +334,7 @@ Verify that you followed each step in the procedure above.  If you are still hav
 [.integr8ly-docs-header]
 === Create a new ActiveDocs Service
 
-. Click *Active Docs* from the side navigation.
+. Click *ActiveDocs* from the side navigation.
 
 . Click *Create your first spec*
 

--- a/walkthroughs/3a-low-code-api-development/walkthrough.adoc
+++ b/walkthroughs/3a-low-code-api-development/walkthrough.adoc
@@ -251,7 +251,7 @@ greetname
 
 . Choose *Name* as the type.
 
-. In the *Responses* section click *Add response*.
+. In the *Responses* section click *Add a response*.
 .. In the window that appears choose *200 OK* as the option.
 .. Click *Add*.
 .. Click *No description* beside the *200 OK* response and enter the following in the *Description* field:
@@ -317,7 +317,7 @@ The *Integration Flow Editor* should now list your Slack connection with a *Data
 
 . From the *Data Mapper* screen click the *body* field in the *Source* panel to expand it.
 
-. Click the *name* field under the *body*, then click the *message* field in the *Target* panel. This maps the value of the incoming HTTP request *body* to the outgoing Slack *message* property.
+. Click the *name* field under the *body*, then click the *body* field in the *Target* panel. This maps the value of the incoming HTTP request *body* to the outgoing Slack *message* property.
 
 . In the right hand *Mapping Details* panel, click the *Add Transformation* under the *Targets* section to add a transformation.
 
@@ -375,21 +375,21 @@ Verify that you followed each step in the procedure above.  If you are still hav
 
 === Adding the App Endpoint to Red Hat 3scale
 
-. From the *Dashboard*, select the *New API* item.
+. From the *APIs* section of the *Dashboard*, select the *New Product* item.
 . Select the *Import from OpenShift* option.
-If this option is not enabled, click *authenticate with OpenShift* to enable the option.
+If this option is not enabled, click *Authenticate to enable this option*
 
 . Choose the *fuse* option from the *Namespace* list.
 . Choose *i-greeting-api* from the *Name* list.
-. Click *Create Service*.
+. Click *Create Product*.
 +
 This process can take a few minutes.
 
 . Edit the API:
 
-.. Choose *API: i-greeting-integration* from the top navigation menu to view the *Overview* page.
+.. Choose *Product: i-greeting-api* from the top navigation menu to view the *Overview* page.
 
-.. From the *Overview* screen, select the *Configure APIcast* link.
+.. Select the *Settings* item in the *Integration* dropdown menu.
 
 .. In the *Staging Public Base URL*, enter:
 +
@@ -398,13 +398,22 @@ This process can take a few minutes.
 {route}
 ----
 
-. In the *MAPPING RULES* section, add a *POST* mapping with the pattern `/greeting`.
+.. Click *Update Product* at the bottom of the page.
 
-.. Select *Update & test in Staging Environment*
+. Create a mapping rule for the `/greeting` endpoint.
+
+.. Select the *Mapping Rules* item in the *Integration* dropdown menu.
+
+.. Click *Add Mapping Rule*
+
+.. Select `POST` in the *Verb* field
+
+.. Enter `/greeting` in the *Pattern* field
+
+.. Click *Create Mapping Rule* at the bottom of the page
 
 [type=verification]
-Is the API service available?
-You might encounter a *403: Authentication failed* or *503 Service Unavailable* message. You can ignore these messages, the issue is resolved in a later step.
+Is the new mapping rule visible from the *Mapping Rules* screen?
 
 [type=verificationFail]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
@@ -441,7 +450,7 @@ low-code-app
 
 . Set a custom *User Key* for the application:
 .. On the *low-code* application screen you were redirected to, scroll to the *API Credentials* section.
-.. Click the green pencil icon beside the *API User Key*
+.. Click the green pencil icon beside the *User Key*
 .. In the *Set Custom User Key* modal dialog, enter:
 +
 [subs="attributes+"]
@@ -453,6 +462,18 @@ test
 
 [type=verification]
 Review the settings in 3scale. Do they match the settings outlined in this task?
+
+[type=verificationFail]
+Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.
+
+=== Staging your API
+
+. Click the *Configuration* menu item in the *Integration* dropdown menu from the side navigation.
+
+. In the *APIcast Configuration* section, click the *Promote to Staging* button
+
+[type=verification]
+Is a new version of the API visible in the *Environments* section of the page?
 
 [type=verificationFail]
 Verify that you followed each step in the procedure above.  If you are still having issues, contact your administrator.


### PR DESCRIPTION
The new Red Hat Integration product release has resulted in products having minor UI changes.

## 3scale 2.7 changes

- Theres a split between "backends" and "products" now
- A person must create a "backend" to point to the backing service (aggregator app)
- A person must create a "product" to be a front to that backend
- Publishing the API to a staging environment only needs to be done once now, no failing publish is required

### Landing page (after startup modal)

<img width="1665" alt="Screenshot 2019-11-24 at 00 25 19" src="https://user-images.githubusercontent.com/8698527/69548148-b8e4da80-0f8e-11ea-8d72-9d61d3d27a62.png">

### new Backend page

<img width="1671" alt="Screenshot 2019-11-25 at 12 15 30" src="https://user-images.githubusercontent.com/8698527/69548377-26910680-0f8f-11ea-8b75-62814c73d4fd.png">

### Backend Overview

<img width="1672" alt="Screenshot 2019-11-24 at 00 52 59" src="https://user-images.githubusercontent.com/8698527/69548483-517b5a80-0f8f-11ea-9814-31e795eb161a.png">

### New Product page

<img width="1673" alt="Screenshot 2019-11-24 at 00 25 30" src="https://user-images.githubusercontent.com/8698527/69548415-36a8e600-0f8f-11ea-887f-d9f66125b934.png">

### Product Overview

<img width="1676" alt="Screenshot 2019-11-24 at 00 50 20" src="https://user-images.githubusercontent.com/8698527/69548468-4cb6a680-0f8f-11ea-8d92-f1e050986afb.png">

