### PR TITLE
Intly 4595

### DIFF
--- a/walkthroughs/1B-protecting-applications-using-rh-sso/walkthrough.adoc
+++ b/walkthroughs/1B-protecting-applications-using-rh-sso/walkthrough.adoc
@@ -153,10 +153,10 @@ demonstrate how to include a configuration and enable the adapter.
 . Select *Applications > Deployments*.
 . Select the *rhmi-lab-nodejs-order-frontend* item from the *Deployments* list.
 . Select the *Environment* tab.
-.. Click the *Add Value from Config Map or Secret*
+.. Click *Add Value from Config Map or Secret*
 .. Enter `KEYCLOAK_CONFIG` in the *Name* column.
 .. Choose `order-entry-keycloak-config` from the *Select a resource* dropdown.
-.. Choose the `KEYCLOAK_CONFIG` in the *Select key* dropdown. 
+.. Choose `KEYCLOAK_CONFIG` in the *Select key* dropdown. 
 . Scroll down and click *Save*.
 . Select *Overview* on the left and find the *rhmi-lab-nodejs-order-frontend* in the list.
 . If a deployment is still in progress, wait for it to finish.

--- a/walkthroughs/1B-protecting-applications-using-rh-sso/walkthrough.adoc
+++ b/walkthroughs/1B-protecting-applications-using-rh-sso/walkthrough.adoc
@@ -73,8 +73,7 @@ Verify that you followed each step in the procedure above and that the *Enabled*
 
 === Creating a User
 
-Red Hat Single Sign-On provides identity brokering functionality. Identity
-brokering facilitates login using a shared identity. For example, it's possible
+Red Hat Single Sign-On provides identity brokering functionality, which facilitates login using a shared identity. For example, it is possible
 to create an *Identity Provider* in a *Realm* in SSO to enable login
 using social identities such as Google, Twitter, or GitHub. When the user
 chooses to login using an *Identity Provider* a *User* is automatically created

--- a/walkthroughs/1B-protecting-applications-using-rh-sso/walkthrough.adoc
+++ b/walkthroughs/1B-protecting-applications-using-rh-sso/walkthrough.adoc
@@ -156,7 +156,7 @@ demonstrate how to include a configuration and enable the adapter.
 .. Click *Add Value from Config Map or Secret*
 .. Enter `KEYCLOAK_CONFIG` in the *Name* column.
 .. Choose `order-entry-keycloak-config` from the *Select a resource* dropdown.
-.. Choose `KEYCLOAK_CONFIG` in the *Select key* dropdown. 
+.. Choose *KEYCLOAK_CONFIG* from the *Select key* menu. 
 . Scroll down and click *Save*.
 . Select *Overview* on the left and find the *rhmi-lab-nodejs-order-frontend* in the list.
 . If a deployment is still in progress, wait for it to finish.


### PR DESCRIPTION
@pwright Review please.

2 things to note.  

- *{customer-sso-name}* resolves to "Customer Application SSO instance".  E.g.
"This Solution Pattern shows you how to use the **Customer Application SSO instance** to enable authentication"
Is this correct?

- sso realm pafge does not work, https://sso-openshift-user-sso.92d7.rhmds-qe1.openshiftapps.com/auth/admin/walkthroughs/console/index.html so was not able to test the functionality so just did the style check.
