### PR TITLE
Update launcher documentation url

### DIFF
--- a/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
+++ b/walkthroughs/2-fuse-aggregator-and-api-management/walkthrough.adoc
@@ -34,7 +34,7 @@ image::images/arch.png[integration, role="integr8ly-img-responsive"]
 ****
 * link:{launcher-url}[Console, window="_blank"]
 * link:https://developers.redhat.com/products/openshiftio/overview/[Launcher Overview, window="_blank"]
-* link:https://launcher.fabric8.io/docs/[Launcher Documentation, window="_blank"]
+* link:https://appdev.openshift.io/docs/[Launcher Documentation, window="_blank"]
 ****
 
 [type=walkthroughResource,serviceName=codeready]


### PR DESCRIPTION
## Description 

The launcher documentation url has change, making the link in solution pattern #2 invalid. 
Jira: https://issues.redhat.com/browse/INTLY-9318

Value in 1.7.1:
https://launcher.fabric8.io/docs

This url has recently been changed to: 
https://appdev.openshift.io/docs
